### PR TITLE
Enable mode-specific prompts for QA

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from langchain_community.embeddings import OpenAIEmbeddings
 from langchain_community.vectorstores import Chroma
 from langchain.chains import RetrievalQA
 from langchain_community.chat_models import ChatOpenAI
-from templates import veritas_prompt
+from templates import prompt_for_mode
 
 # 1) Read API key
 api_key = os.getenv("OPENAI_API_KEY")
@@ -30,12 +30,12 @@ llm = ChatOpenAI(
     openai_api_key=api_key
 )
 
-# 5) Build the QA chain
+# 5) Build the QA chain with default (both sources) prompt
 db_qa = RetrievalQA.from_chain_type(
     llm=llm,
     chain_type="stuff",
     retriever=retriever,
-    chain_type_kwargs={"prompt": veritas_prompt}
+    chain_type_kwargs={"prompt": prompt_for_mode("both")}
 )
 
 # 6) Create FastAPI app and enable CORS
@@ -82,7 +82,7 @@ def qa(request: QARequest):
         llm=llm,
         chain_type="stuff",
         retriever=local_retriever,
-        chain_type_kwargs={"prompt": veritas_prompt},
+        chain_type_kwargs={"prompt": prompt_for_mode(request.mode.value)},
     )
 
     res = chain.invoke({"query": request.question})

--- a/templates.py
+++ b/templates.py
@@ -1,17 +1,17 @@
 from langchain.prompts import PromptTemplate
 
 veritas_prompt = PromptTemplate(
-    input_variables=["context", "question"],
+    input_variables=["context", "question", "mode"],
     template="""
 You are **Veritas AI**, a Catholic teaching assistant. Use **only** the passages below—drawn from Scripture and the Catechism—to answer the user’s question.
 
 **INSTRUCTIONS**
+- {mode}
 - Never say “it doesn’t address…” or “you’ve shared…”—just answer.
 - Always quote relevant passages **in full**, with inline citations like `(Book Chap:Verse)` or `[CCC §#]`.
-- Include at least one CCC passage **and** at least one Bible passage in every answer, unless the user specifically requested only one source type.
-- Strive for at least **4 sources total**, aiming for a **50/50 balance** between Bible and CCC.
+- Strive for at least **4 sources total**.
 - Never mention that a source doesn’t cover a topic—simply answer using what’s available.
-- Blend CCC and Bible seamlessly (unless the question demands one exclusively).
+- Blend CCC and Bible seamlessly when both are allowed.
 
 **OUTPUT FORMAT**
 1. Print the **Question** exactly as provided.
@@ -43,3 +43,18 @@ Question: {question}
 
 """
 )
+
+
+def prompt_for_mode(mode: str) -> PromptTemplate:
+    """Return a prompt with instructions based on the selected mode."""
+    if mode == "bible":
+        mode_text = (
+            "Cite only passages from the Bible. Do not mention the Catechism."
+        )
+    elif mode == "catechism":
+        mode_text = (
+            "Cite only passages from the Catechism (CCC). Do not mention the Bible."
+        )
+    else:
+        mode_text = "Blend passages from both the Bible and the Catechism."
+    return veritas_prompt.partial(mode=mode_text)


### PR DESCRIPTION
## Summary
- add `mode` variable to prompt template and helper `prompt_for_mode`
- build default QA chain with the "both" prompt
- update `/qa` endpoint to pass mode-specific prompt

## Testing
- `python -m py_compile app.py templates.py qa_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7ed5f3e08323a20fec1dfa5369e0