### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# GraceGuide MVP
+
+This project provides a small FastAPI service powered by LangChain with a Vite/Vanilla JS frontend. The service exposes a `/qa` endpoint for question answering and a `/subscribe` endpoint for email sign‑ups.
+
+## Prerequisites
+
+- **Python**: 3.11 or newer
+- **Node.js**: 18 or newer (for the frontend build)
+- **npm**: comes with Node and is used to run Vite
+
+## Installation
+
+Install Python packages:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+Install frontend dependencies:
+
+```bash
+cd graceguide-ui
+npm install
+```
+
+## Environment variables
+
+Set your OpenAI key so both the database script and the API can embed and query text:
+
+```bash
+export OPENAI_API_KEY=your-openai-key
+```
+
+The `/subscribe` endpoint uses a mailing‑list provider. Define the following variables so the endpoint can add emails to your list (values depend on your provider):
+
+```bash
+export MAILCHIMP_API_KEY=your-mailchimp-api-key
+export MAILCHIMP_SERVER_PREFIX=us1        # e.g. 'us1'
+export MAILCHIMP_LIST_ID=abc123456
+```
+
+## Building the Chroma database
+
+Run the build script once after setting `OPENAI_API_KEY`:
+
+```bash
+python3 build_db.py
+```
+
+This creates the `veritas_ai_chroma_db/` directory used by the API.
+
+## Starting the FastAPI server
+
+After the database exists you can start the server:
+
+```bash
+uvicorn app:app --reload --port 8000
+```
+
+The UI in `graceguide-ui/dist` will be served automatically if it has been built.
+
+## Building the frontend
+
+To build the static frontend with Vite:
+
+```bash
+cd graceguide-ui
+npm run build
+```
+
+The output appears in `graceguide-ui/dist/`. When the API is running these files are served as the root website so you can navigate to `http://localhost:8000/` to use the app.


### PR DESCRIPTION
## Summary
- document Python and Node prerequisites
- explain building the Chroma DB and the frontend
- add environment variables including ones for the `/subscribe` endpoint

## Testing
- `python3 -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_683f86f4db5c83238ca1bfba773b336a