### PR TITLE
Fix landing page file path

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,7 +147,7 @@ if os.path.isdir(ui_path):
 
     @app.get("/", include_in_schema=False)
     def landing_page():
-        return FileResponse(os.path.join(ui_path, "src", "landing.html"))
+        return FileResponse(os.path.join(ui_path, "index.html"))
 
     @app.get("/app", include_in_schema=False)
     def qa_page():


### PR DESCRIPTION
## Summary
- serve the built landing page from `index.html`
- confirm server starts

## Testing
- `npm install`
- `npm run build`
- `pip install -r requirements.txt`
- `uvicorn app:app --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_683f8dd5faf883239a18e864c7b0db3d