### PR TITLE
Fix header alignment and reposition sidebar contents

### DIFF
--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -82,11 +82,11 @@
 
   <body class="bg-gray-50 min-h-screen flex flex-col">
     <!-- ░░░ Header ░░░ -->
-    <header class="bg-brand text-white px-4 py-6">
-      <h1 class="text-2xl sm:text-3xl font-semibold text-center sm:text-left">
+    <header class="bg-brand text-white px-4 py-6 text-center">
+      <h1 class="text-2xl sm:text-3xl font-semibold">
         GraceGuideAI&nbsp;<span class="font-light">Beta</span>
       </h1>
-      <p class="mt-2 text-center sm:text-left opacity-90">
+      <p class="mt-2 opacity-90">
         Catholic answers powered by Scripture&nbsp;&amp;&nbsp;Catechism
       </p>
     </header>
@@ -114,7 +114,7 @@
     <main
       class="w-full max-w-4xl mx-auto flex-1 px-4 py-8 flex flex-col lg:flex-row gap-6"
     >
-      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white p-4 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
+      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white pt-12 px-4 pb-4 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
         <h2 class="text-lg font-semibold mb-2">Past Answers</h2>
         <ul id="historyList" class="space-y-4 text-sm"></ul>
       </aside>


### PR DESCRIPTION
## Summary
- center header content on desktop
- offset Past Answers sidebar so button doesn't overlap
- rebuild frontend assets

## Testing
- `./scripts/build_frontend.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe6a1b93c83238379c8c2f8e324f7