### PR TITLE
Fix header alignment and history sidebar layout

### DIFF
--- a/graceguide-ui/dist/index.html
+++ b/graceguide-ui/dist/index.html
@@ -84,10 +84,10 @@
   <body class="bg-gray-50 min-h-screen flex flex-col">
     <!-- ░░░ Header ░░░ -->
     <header class="bg-brand text-white px-4 py-6">
-      <h1 class="text-2xl sm:text-3xl font-semibold text-center sm:text-left">
+      <h1 class="text-2xl sm:text-3xl font-semibold text-center">
         GraceGuideAI&nbsp;<span class="font-light">Beta</span>
       </h1>
-      <p class="mt-2 text-center sm:text-left opacity-90">
+      <p class="mt-2 text-center opacity-90">
         Catholic answers powered by Scripture&nbsp;&amp;&nbsp;Catechism
       </p>
     </header>
@@ -115,7 +115,7 @@
     <main
       class="w-full max-w-4xl mx-auto flex-1 px-4 py-8 flex flex-col lg:flex-row gap-6"
     >
-      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white p-4 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
+      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white p-4 pt-12 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
         <h2 class="text-lg font-semibold mb-2">Past Answers</h2>
         <ul id="historyList" class="space-y-4 text-sm"></ul>
       </aside>

--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -83,10 +83,10 @@
   <body class="bg-gray-50 min-h-screen flex flex-col">
     <!-- ░░░ Header ░░░ -->
     <header class="bg-brand text-white px-4 py-6">
-      <h1 class="text-2xl sm:text-3xl font-semibold text-center sm:text-left">
+      <h1 class="text-2xl sm:text-3xl font-semibold text-center">
         GraceGuideAI&nbsp;<span class="font-light">Beta</span>
       </h1>
-      <p class="mt-2 text-center sm:text-left opacity-90">
+      <p class="mt-2 text-center opacity-90">
         Catholic answers powered by Scripture&nbsp;&amp;&nbsp;Catechism
       </p>
     </header>
@@ -114,7 +114,7 @@
     <main
       class="w-full max-w-4xl mx-auto flex-1 px-4 py-8 flex flex-col lg:flex-row gap-6"
     >
-      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white p-4 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
+      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white p-4 pt-12 border border-gray-200 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform">
         <h2 class="text-lg font-semibold mb-2">Past Answers</h2>
         <ul id="historyList" class="space-y-4 text-sm"></ul>
       </aside>


### PR DESCRIPTION
## Summary
- keep header text centered on all screen sizes
- shift history sidebar contents down so Past Answers heading doesn't overlap the toggle button
- rebuild static assets

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fec21cd288323ac1cea2e885691e3