### PR TITLE
Fix dark-mode textarea and dev proxy

### DIFF
--- a/graceguide-ui/dist/index.html
+++ b/graceguide-ui/dist/index.html
@@ -141,7 +141,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 

--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -140,7 +140,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 

--- a/graceguide-ui/vite.config.js
+++ b/graceguide-ui/vite.config.js
@@ -3,6 +3,12 @@ import { resolve } from 'path';
 
 export default defineConfig({
   base: '/static/',
+  server: {
+    proxy: {
+      '/qa': 'http://localhost:8000',
+      '/subscribe': 'http://localhost:8000'
+    }
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- tweak QA textarea styling so text is readable in dark mode
- configure Vite dev server to proxy API requests

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fff0a1b688323be9b6db3fec74443