### PR TITLE
Add npm ci prebuild step

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ npm install
 # Installs Vite and other packages so the build script can run successfully
 ```
 
+`npm run build` now runs `npm ci` automatically via a `prebuild` script, so packages
+will be installed if they're missing.
+
 ## Environment variables
 
 Set your OpenAI key so both the database script and the API can embed and query text:
@@ -69,6 +72,9 @@ To build the static frontend with Vite use the provided script:
 ```bash
 ./scripts/build_frontend.sh
 ```
+
+You can also run `npm run build` directly; it will install dependencies first
+thanks to the new `prebuild` step.
 
 The output appears in `graceguide-ui/dist/`. When the API is running these files are served as the root website so you can navigate to `http://localhost:8000/` to use the app.
 

--- a/graceguide-ui/package.json
+++ b/graceguide-ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm ci",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- run `npm ci` before `npm run build`
- document automatic install during `npm run build`

## Testing
- `python3 -m py_compile app.py build_db.py qa_agent.py templates.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400118e7b08323bb73d5179934bd81