### PR TITLE
Fix question box dark mode and server error messaging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -100,7 +100,10 @@ def qa(request: QARequest):
         chain_type_kwargs={"prompt": prompt_for_mode(request.mode.value)},
     )
 
-    res = chain.invoke({"query": request.question})
+    try:
+        res = chain.invoke({"query": request.question})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
     raw = res["result"].strip()
 
     if "=== Sources ===" in raw:

--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -140,7 +140,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 


### PR DESCRIPTION
## Summary
- style the question textarea so text is visible in dark mode
- surface backend errors via HTTPException for `/qa`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840054e835c832380c60b25aa5c80cd