### PR TITLE
Improve dark mode textarea contrast

### DIFF
--- a/graceguide-ui/dist/index.html
+++ b/graceguide-ui/dist/index.html
@@ -141,7 +141,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-brand dark:border-gray-600"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 

--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -140,7 +140,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-brand dark:border-gray-600"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 


### PR DESCRIPTION
## Summary
- tweak textarea color in dark mode so typed text is visible
- rebuild frontend

## Testing
- `./scripts/build_frontend.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840083c968c8323af9ba3d2074d16d3