### PR TITLE
Fix dark-mode textarea text color

### DIFF
--- a/graceguide-ui/dist/index.html
+++ b/graceguide-ui/dist/index.html
@@ -141,7 +141,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-brand dark:border-gray-600"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-white dark:border-gray-600"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 

--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -140,7 +140,7 @@
       <textarea
         id="question"
         rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-brand dark:border-gray-600"
+        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-white dark:border-gray-600"
         placeholder="e.g. What does the Catechism say about forgiveness?"
       ></textarea>
 


### PR DESCRIPTION
## Summary
- make the question textarea use white text in dark mode

## Testing
- `python3 -m py_compile build_db.py qa_agent.py app.py templates.py`

------
https://chatgpt.com/codex/tasks/task_e_68400ae444148323976581f70f457aa0