### PR TITLE
Add Mailchimp email signup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ export MAILCHIMP_SERVER_PREFIX=us1        # e.g. 'us1'
 export MAILCHIMP_LIST_ID=abc123456
 ```
 
+If these variables are not set or Mailchimp returns an error, emails are stored
+locally in `subscribers.csv`. The endpoint checks both your Mailchimp list and
+the CSV file to avoid duplicates.
+
 ## Building the Chroma database
 
 Run the build script once after setting `OPENAI_API_KEY`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 tiktoken
 langchain-openai
 langchain-chroma
+requests


### PR DESCRIPTION
## Summary
- integrate Mailchimp with `/subscribe`
- store email locally if Mailchimp creds are missing or fail
- avoid duplicates in both Mailchimp and CSV
- document fallback behaviour
- add `requests` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840abcbd8688323975514be528734b7