### PR TITLE
Enable native sharing for saved images

### DIFF
--- a/graceguide-ui/src/main.js
+++ b/graceguide-ui/src/main.js
@@ -361,3 +361,13 @@ emailShare.addEventListener("click", async () => {
     window.location.href = "mailto:?subject=GraceGuideAI%20Q%26A";
   }
 });
+
+downloadShare.addEventListener("click", async e => {
+  if (navigator.canShare && navigator.canShare({ files: [shareFile] })) {
+    e.preventDefault();
+    downloadShare.removeAttribute("download");
+    try {
+      await navigator.share({ files: [shareFile] });
+    } catch (_) {}
+  }
+});


### PR DESCRIPTION
## Summary
- add `downloadShare` click handler
- share the generated image via `navigator.share` if the browser supports files

## Testing
- `npm run build` in `graceguide-ui`
- `python -m py_compile qa_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_684cb64c909083238a689b5f864e4afe