### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- enable Dependabot with npm updates on a daily schedule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68753b952db08323b337c881367835b3