### PR TITLE
Integrate React dashboards

### DIFF
--- a/graceguide-ui/index.html
+++ b/graceguide-ui/index.html
@@ -2,300 +2,32 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>GraceGuideAI — Catholic Q & A</title>
 
     <!-- Google AdSense (must stay!) -->
-    <script async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5110239623159372"
-            crossorigin="anonymous"></script>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5110239623159372" crossorigin="anonymous"></script>
 
-    <!-- ❶ Tailwind CDN (quickest route for MVP) -->
+    <!-- Tailwind via CDN for quick prototyping -->
     <script src="https://cdn.tailwindcss.com"></script>
-
-    <!-- ❷ Dark‑mode + brand colour (Marian blue) -->
     <script>
       tailwind.config = {
-        darkMode: "class",
-        theme: {
-          extend: { colors: { brand: "#0054a6" } }
-        }
-      }
+        darkMode: 'class',
+        theme: { extend: { colors: { brand: '#0054a6' } } }
+      };
     </script>
 
-    <!-- ❸ Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Merriweather:wght@400;700&display=swap" rel="stylesheet" />
-
-    <!-- ❹ Global styles -->
     <style>
-      * { font-family: "Merriweather", "Inter", system-ui, sans-serif; }
-      .slider {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 9rem;
-        height: 0.5rem;
-        border-radius: 0.25rem;
-        background: #e5e7eb;
-        outline: none;
-        transition: background 0.3s ease;
-        cursor: pointer;
-      }
-      .slider::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 1.25rem;
-        height: 1.25rem;
-        border-radius: 9999px;
-        background: #0054a6;
-        transition: background 0.3s ease;
-      }
-      .slider::-moz-range-thumb {
-        width: 1.25rem;
-        height: 1.25rem;
-        border-radius: 9999px;
-        background: #0054a6;
-        border: none;
-        transition: background 0.3s ease;
-      }
-      .src-btn.active {
-        background-color: #0054a6;
-        color: white;
-      }
-      /* History sidebar styling */
-      #historyList {
-        list-style: none;
-        padding-left: 0;
-      }
-      .history-item details {
-        background-color: rgba(255, 255, 255, 0.9);
-        border-radius: 0.5rem;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-        padding: 0.5rem;
-        overflow: hidden;
-        transition: box-shadow 0.3s ease, background-color 0.3s ease;
-      }
-      .dark .history-item details {
-        background-color: #374151;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-      }
-      .history-item summary {
-        cursor: pointer;
-        padding: 0.25rem 0.5rem;
-        border-radius: 0.375rem;
-        transition: background-color 0.2s ease;
-        list-style: none;
-        font-weight: 600;
-      }
-      .history-item .question-text {
-        flex: 1;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .history-item summary:hover {
-        background-color: #f3f4f6; /* gray-100 */
-      }
-      .dark .history-item summary:hover {
-        background-color: #4b5563; /* gray-600 */
-      }
-      .history-item details[open] summary {
-        margin-bottom: 0.25rem;
-      }
-      .history-item .qa {
-        margin-left: 0.5rem;
-      }
-      .share-btn {
-        opacity: 0;
-        transition: opacity 0.2s ease;
-      }
-      .history-item:hover .share-btn {
-        opacity: 1;
-      }
-      #sharePreview {
-        aspect-ratio: 9 / 16;
-      }
+      * { font-family: 'Merriweather', 'Inter', system-ui, sans-serif; }
     </style>
   </head>
 
-  <body class="bg-gray-50 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col">
-    <!-- ░░░ Header ░░░ -->
-
-<header>
-  <div class="flex flex-col sm:flex-row items-center justify-between bg-gradient-to-r from-blue-900 to-blue-600 text-white shadow-lg px-4 py-4">
-    <div class="flex flex-col sm:flex-row items-center">
-      <div class="flex items-center space-x-2">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-[#FFD700]" fill="currentColor" viewBox="0 0 24 24"><path d="M10 2v6H4v8h6v6h4v-6h6V8h-6V2z"/></svg>
-        <h1 class="text-2xl font-semibold">GraceGuideAI</h1>
-      </div>
-      <p class="text-sm sm:text-base text-[#FFD700] sm:ml-4">Catholic answers powered by Scripture &amp; Catechism</p>
-    </div>
-<button id="themeToggle" class="bg-white/20 hover:bg-white/30 rounded p-2" aria-label="Toggle dark mode">
-  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 20 20">
-    <path d="M17.293 13.293A8 8 0 0110.707 2.707a8 8 0 106.586 10.586z" />
-  </svg>
-</button>
-  </div>
-</header>
-    <button
-      id="historyToggle"
-      class="fixed top-2 left-2 z-40 p-2 bg-brand text-white rounded-md"
-      aria-label="Toggle history"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-6 w-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    </button>
-
-
-    <!-- ░░░ Main Q&A ░░░ -->
-    <main
-      class="w-full max-w-4xl mx-auto flex-1 px-4 py-8 flex flex-col lg:flex-row gap-6"
-    >
-      <aside id="history" class="fixed inset-y-0 left-0 z-30 w-72 bg-white/80 lg:bg-white/90 dark:bg-gray-800 p-4 pt-12 border border-gray-200 dark:border-gray-600 rounded-r-md overflow-y-auto transform -translate-x-full transition-transform dark:text-gray-100">
-        <h2 class="text-lg font-semibold mb-2">History</h2>
-        <ul id="historyList" class="space-y-4 text-sm"></ul>
-      </aside>
-
-      <div id="qaContainer" class="flex-1 flex flex-col space-y-6 transition-all">
-      <!-- Question -->
-      <label class="text-sm font-medium text-gray-700">Ask your question</label>
-      <textarea
-        id="question"
-        rows="4"
-        class="mt-1 p-3 w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand/20 resize-y dark:bg-gray-700 dark:text-white dark:border-gray-600"
-        placeholder="e.g. What does the Catechism say about forgiveness?"
-      ></textarea>
-
-      <!-- Source toggle & Ask button -->
-      <div class="flex items-center justify-between">
-        <div class="flex flex-col items-center gap-2" id="sourceButtons">
-          <input
-            type="range"
-            id="sourceSlider"
-            min="0"
-            max="2"
-            step="1"
-            value="0"
-            class="slider"
-          />
-          <div class="flex justify-between text-xs text-gray-600 w-36">
-            <span>Blend</span>
-            <span>Bible</span>
-            <span>CCC</span>
-          </div>
-        </div>
-        <button
-          id="ask"
-          class="bg-brand hover:bg-brand/90 text-white px-6 py-2 rounded-md flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <span id="askLabel">Ask</span>
-          <svg
-            id="spinner"
-            class="hidden animate-spin h-4 w-4"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none" viewBox="0 0 24 24"
-          >
-            <circle class="opacity-25" cx="12" cy="12" r="10"
-                    stroke="currentColor" stroke-width="4" />
-            <path class="opacity-75" fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-          </svg>
-        </button>
-      </div>
-
-      <!-- Answer area -->
-      <section id="answerCard" class="hidden space-y-4">
-        <h2 class="text-lg font-semibold">Answer</h2>
-        <pre
-          id="output"
-          class="whitespace-pre-wrap bg-white dark:bg-gray-800 p-4 rounded-md border border-gray-200 dark:border-gray-600 text-gray-800 dark:text-gray-100"
-        ></pre>
-        <h3 class="text-md font-semibold">Sources</h3>
-        <ul
-          id="sourceList"
-          class="list-disc pl-6 space-y-1 text-gray-700 dark:text-gray-100"
-        ></ul>
-      </section>
-      </div>
-    </main>
-
-    <footer class="text-center text-xs text-gray-500 dark:text-gray-400 py-4">
-      © 2025 GraceGuideAI · Beta preview
-    </footer>
-
-    <!-- Email capture modal -->
-    <div
-      id="emailModal"
-      class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center opacity-0 transition-opacity duration-300"
-    >
-      <div id="modalContent" class="opacity-0 scale-90 transform transition-all duration-300 bg-white dark:bg-gray-800 rounded-[16px] shadow-[0_8px_32px_rgba(0,0,0,0.12)] w-11/12 max-w-xl h-auto p-8 space-y-4" role="dialog" aria-labelledby="newsletterTitle" aria-modal="true">
-        <header class="flex justify-between items-center bg-[#1e3a8a] text-white -mt-8 -mx-8 p-4 rounded-t-[16px]">
-          <h2 id="newsletterTitle" class="text-lg font-semibold flex items-center gap-2">
-            <span>✟</span>
-            Join 100+ Catholics deepening their faith daily
-          </h2>
-          <button id="closeModal" class="text-white text-xl leading-none" aria-label="Close">&times;</button>
-        </header>
-        <p class="text-sm text-gray-700 dark:text-gray-300">
-          Receive weekly Gospel reflections, Scripture insights, and spiritual guidance directly to your inbox.
-        </p>
-        <input id="emailInput" aria-label="Email address" type="email" placeholder="Email address" class="w-full border p-3 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
-        <p class="text-xs text-gray-500 dark:text-gray-400">Unsubscribe anytime with one click.</p>
-        <div class="flex justify-end gap-4">
-          <button id="joinNow" class="bg-gradient-to-r from-blue-700 to-blue-500 text-white px-6 py-3 rounded-md flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed">
-            <span id="joinLabel">Join Our Faith Community</span>
-            <svg id="joinSpinner" class="hidden animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-            </svg>
-          </button>
-      <button id="maybeLater" class="text-brand underline">Maybe Later</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Share modal -->
-    <div id="shareModal" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center opacity-0 transition-opacity duration-300">
-      <div id="shareContent" class="opacity-0 scale-90 transform transition-all duration-300 bg-white dark:bg-gray-800 rounded-md shadow-lg max-h-[90vh] overflow-y-auto w-11/12 max-w-lg p-4 space-y-4" role="dialog" aria-labelledby="shareTitle" aria-modal="true">
-        <img id="sharePreview" class="w-full rounded" alt="Share preview" />
-        <div class="flex flex-wrap justify-center gap-2">
-          <a id="downloadShare" class="share-action flex items-center gap-1 bg-brand text-white px-3 py-2 rounded-md" download="graceguide.png">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4"><path d="M12 16V4m0 12l-3-3m3 3l3-3M4 20h16"/></svg>
-            <span id="downloadLabel">Download</span>
-          </a>
-          <button id="xShare" class="share-action flex items-center gap-1 bg-black text-white px-3 py-2 rounded-md">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4"><path d="M4 4l16 16M20 4L4 20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-            <span>Share to X</span>
-          </button>
-          <button id="instaShare" class="share-action flex items-center gap-1 bg-gradient-to-r from-yellow-400 via-red-500 to-purple-600 text-white px-3 py-2 rounded-md">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4"><path d="M7 2h10a5 5 0 015 5v10a5 5 0 01-5 5H7a5 5 0 01-5-5V7a5 5 0 015-5zm5 5a5 5 0 100 10 5 5 0 000-10zm6.5-.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/></svg>
-            <span>Instagram</span>
-          </button>
-          <button id="emailShare" class="share-action flex items-center gap-1 bg-gray-600 text-white px-3 py-2 rounded-md">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4"><path d="M2.25 4.5h19.5v15H2.25v-15z" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M2.25 4.5l9.75 7.5 9.75-7.5" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
-            <span>Email</span>
-          </button>
-          <button id="closeShare" class="text-brand underline">Close</button>
-        </div>
-      </div>
-    </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
-    <!-- Vite entry -->
-    <script type="module" src="/src/main.js"></script>
+  <body class="bg-gray-50 dark:bg-gray-900 dark:text-gray-100 min-h-screen">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>
+

--- a/graceguide-ui/src/App.jsx
+++ b/graceguide-ui/src/App.jsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react';
+import GuestDashboard from './components/GuestDashboard.jsx';
+import SignedInDashboard from './components/SignedInDashboard.jsx';
+
+export default function App() {
+  const [signedIn, setSignedIn] = useState(false);
+
+  return signedIn ? (
+    <SignedInDashboard onSignOut={() => setSignedIn(false)} />
+  ) : (
+    <GuestDashboard onSignIn={() => setSignedIn(true)} />
+  );
+}
+

--- a/graceguide-ui/src/components/GuestDashboard.jsx
+++ b/graceguide-ui/src/components/GuestDashboard.jsx
@@ -1,6 +1,20 @@
 import React from 'react';
 
-function GuestDashboard() {
+function Footer() {
+  return (
+    <footer className="text-center text-xs text-gray-500 py-4 border-t">
+      <a href="#" className="mx-2 hover:underline">About</a>
+      <span>&bull;</span>
+      <a href="#" className="mx-2 hover:underline">Privacy</a>
+      <span>&bull;</span>
+      <a href="#" className="mx-2 hover:underline">Terms</a>
+      <span>&bull;</span>
+      <a href="#" className="mx-2 hover:underline">Contact</a>
+    </footer>
+  );
+}
+
+function GuestDashboard({ onSignIn }) {
   return (
     <div className="min-h-screen flex flex-col">
       {/* Header */}
@@ -12,7 +26,12 @@ function GuestDashboard() {
           GraceGuideAI
         </div>
         <div className="space-x-2">
-          <button className="text-brand font-medium">Sign In</button>
+          <button
+            className="text-brand font-medium"
+            onClick={() => onSignIn && onSignIn()}
+          >
+            Sign In
+          </button>
           <button className="bg-brand text-white px-3 py-1 rounded-md">Sign Up</button>
         </div>
       </header>
@@ -45,17 +64,10 @@ function GuestDashboard() {
       </main>
 
       {/* Footer */}
-      <footer className="text-center text-xs text-gray-500 py-4 border-t">
-        <a href="#" className="mx-2 hover:underline">About</a>
-        <span>&bull;</span>
-        <a href="#" className="mx-2 hover:underline">Privacy</a>
-        <span>&bull;</span>
-        <a href="#" className="mx-2 hover:underline">Terms</a>
-        <span>&bull;</span>
-        <a href="#" className="mx-2 hover:underline">Contact</a>
-      </footer>
+      <Footer />
     </div>
   );
 }
 
+GuestDashboard.Footer = Footer;
 export default GuestDashboard;

--- a/graceguide-ui/src/components/SignedInDashboard.jsx
+++ b/graceguide-ui/src/components/SignedInDashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import GuestDashboard from './GuestDashboard';
 
-function SignedInDashboard({ name = 'Friend' }) {
+function SignedInDashboard({ name = 'Friend', onSignOut }) {
   return (
     <div className="flex flex-col min-h-screen">
       <header className="flex items-center justify-between p-4 border-b">
@@ -14,6 +14,11 @@ function SignedInDashboard({ name = 'Friend' }) {
           <button title="Saved">💾</button>
           <button title="Settings">⚙️</button>
           <img src="/avatar.png" alt="Avatar" className="h-8 w-8 rounded-full" />
+          {onSignOut && (
+            <button className="text-sm underline" onClick={onSignOut}>
+              Sign Out
+            </button>
+          )}
         </div>
       </header>
 

--- a/graceguide-ui/src/main.jsx
+++ b/graceguide-ui/src/main.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-
-function App() {
-  return <div>Hello from React</div>;
-}
+import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- replace the app HTML with a small page that mounts React
- expose a `Footer` component for reuse in `GuestDashboard`
- allow signing in/out between guest and signed in dashboards
- wire up a small `App` component and render it from `main.jsx`

## Testing
- `npm run build` within `graceguide-ui`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68756c86223c8323a71ac19222a35a91