### PR TITLE
Switch to bcrypt for password hashing

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import os
 import json
 from pathlib import Path
-import hashlib
+import bcrypt
 import secrets
 import jwt
 from datetime import datetime, timedelta
@@ -118,8 +118,12 @@ class AuthResponse(BaseModel):
     email: str
 
 def hash_password(password: str) -> str:
-    """Hash password with salt"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using bcrypt with a generated salt"""
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """Verify a password against an existing hash"""
+    return bcrypt.checkpw(password.encode(), password_hash.encode())
 
 def create_jwt_token(email: str) -> str:
     """Create JWT token for user"""
@@ -167,7 +171,7 @@ def signin(request: AuthRequest):
         raise HTTPException(status_code=401, detail="Invalid credentials")
     
     # Verify password
-    if users[email]["password_hash"] != hash_password(request.password):
+    if not verify_password(request.password, users[email]["password_hash"]):
         raise HTTPException(status_code=401, detail="Invalid credentials")
     
     # Create token

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ langchain-openai
 langchain-chroma
 requests
 PyJWT
+bcrypt


### PR DESCRIPTION
## Summary
- use bcrypt with generated salts for password hashing
- add verify_password helper and use it during signin
- add bcrypt dependency

## Testing
- `python -m py_compile app.py`
- `pytest`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e5d798083239daefb5e516f2db8