### PR TITLE
Handle user save errors with logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import secrets
 import jwt
 from datetime import datetime, timedelta
 import random
+import logging
 
 # JWT secret key
 JWT_SECRET = os.getenv("JWT_SECRET", "your-secret-key-change-in-production")
@@ -135,8 +136,10 @@ def save_users():
     try:
         with USERS_FILE.open("w") as f:
             json.dump(users, f)
-    except Exception:
-        pass
+        return True
+    except Exception as e:
+        logging.error("Failed to save users: %s", e)
+        return False
 
 # Authentication endpoints
 @app.post("/auth/signup", response_model=AuthResponse)
@@ -152,7 +155,8 @@ def signup(request: AuthRequest):
         "password_hash": hash_password(request.password),
         "created_at": datetime.utcnow().isoformat()
     }
-    save_users()
+    if not save_users():
+        raise HTTPException(status_code=500, detail="Failed to save user data")
     
     # Create token
     token = create_jwt_token(email)


### PR DESCRIPTION
## Summary
- import `logging` into the FastAPI app
- log failures when saving users and report errors during signup

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e65d1e88323938e88046cd248a8