### PR TITLE
Simplify verse of the day endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,8 +194,6 @@ def signin(request: AuthRequest):
 class VerseOfTheDayResponse(BaseModel):
     verse_text: str
     verse_reference: str
-    explanation: str
-    catechism_references: list[str]
 
 # Load meaningful verses for daily selection
 MEANINGFUL_VERSES = [
@@ -223,78 +221,41 @@ verse_of_day_cache = {}
 def get_verse_of_the_day():
     # Use current date as key for consistent daily verse
     today = datetime.utcnow().date().isoformat()
-    
+
     # Check cache first
     if today in verse_of_day_cache:
         return VerseOfTheDayResponse(**verse_of_day_cache[today])
-    
+
     # Select verse based on day of year for consistency
     day_of_year = datetime.utcnow().timetuple().tm_yday
     verse_index = day_of_year % len(MEANINGFUL_VERSES)
     selected_verse = MEANINGFUL_VERSES[verse_index]
-    
+
     # Get verse text from preloaded Bible data
     try:
-        verse_text = BIBLE_DATA.get(selected_verse["book"], {}).get(
-            selected_verse["chapter"], {}
-        ).get(selected_verse["verse"], "Verse not found")
+        verse_text = (
+            BIBLE_DATA.get(selected_verse["book"], {})
+            .get(selected_verse["chapter"], {})
+            .get(selected_verse["verse"], "Verse not found")
+        )
 
         verse_reference = f"{selected_verse['book']} {selected_verse['chapter']}:{selected_verse['verse']}"
-        
-        # Generate explanation using the LLM with Catechism context
-        prompt = f"""Given this Bible verse: "{verse_text}" ({verse_reference})
 
-Please provide a brief Catholic explanation (2-3 sentences) that:
-1. Explains the spiritual meaning of this verse
-2. Connects it to Catholic teaching from the Catechism
-3. Offers a practical application for daily life
-
-Keep the explanation concise and accessible."""
-
-        # Search for relevant Catechism passages
-        theme_filter = {"source": "CCC"}
-        catechism_retriever = vectorstore.as_retriever(
-            search_kwargs={"k": 3, "filter": theme_filter}
-        )
-        
-        # Get relevant CCC passages based on the verse theme
-        search_query = f"{selected_verse['theme']} {verse_text[:50]}"
-        relevant_docs = catechism_retriever.get_relevant_documents(search_query)
-        
-        # Extract CCC references
-        catechism_refs = []
-        for doc in relevant_docs:
-            ref = doc.metadata.get("reference", "")
-            if ref and ref not in catechism_refs:
-                catechism_refs.append(ref)
-        
-        # Generate explanation
-        try:
-            response = llm.invoke(prompt)
-            explanation = str(response.content).strip() if hasattr(response, 'content') else str(response).strip()
-        except Exception as e:
-            explanation = "This verse reminds us of God's infinite love and mercy. The Catechism teaches us that Scripture is the living Word of God, speaking to us today. Let us meditate on this verse and apply its wisdom to our daily lives."
-        
-        # Prepare response
         result = {
             "verse_text": verse_text,
             "verse_reference": verse_reference,
-            "explanation": explanation,
-            "catechism_references": catechism_refs[:2]  # Limit to 2 references
         }
-        
+
         # Cache the result
         verse_of_day_cache[today] = result
-        
+
         return VerseOfTheDayResponse(**result)
-        
+
     except Exception as e:
         # Fallback response
         return VerseOfTheDayResponse(
             verse_text="For God so loved the world, as to give his only begotten Son: that whosoever believeth in him may not perish, but may have life everlasting.",
             verse_reference="John 3:16",
-            explanation="This verse encapsulates the heart of the Gospel - God's infinite love for humanity. The Catechism teaches that God's love is the source of our salvation. Today, let us reflect on how we can share this divine love with others.",
-            catechism_references=["CCC 457", "CCC 458"]
         )
 
 # 7) /qa endpoint

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,417 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Veritas AI QA API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/auth/signup": {
+      "post": {
+        "summary": "Signup",
+        "operationId": "signup_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/signin": {
+      "post": {
+        "summary": "Signin",
+        "operationId": "signin_auth_signin_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/verse-of-the-day": {
+      "get": {
+        "summary": "Get Verse Of The Day",
+        "operationId": "get_verse_of_the_day_verse_of_the_day_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerseOfTheDayResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/qa": {
+      "post": {
+        "summary": "Qa",
+        "operationId": "qa_qa_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QARequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QAResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscribe": {
+      "post": {
+        "summary": "Subscribe",
+        "operationId": "subscribe_subscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscribeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Get Metrics",
+        "operationId": "get_metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ]
+      }
+    },
+    "/log_event": {
+      "post": {
+        "summary": "Log Event",
+        "operationId": "log_event_log_event_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AuthRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "AuthRequest"
+      },
+      "AuthResponse": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "email"
+        ],
+        "title": "AuthResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "LogEvent": {
+        "properties": {
+          "event": {
+            "type": "string",
+            "title": "Event"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event"
+        ],
+        "title": "LogEvent"
+      },
+      "QARequest": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "title": "Question"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/SourceMode",
+            "default": "both"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question"
+        ],
+        "title": "QARequest"
+      },
+      "QAResponse": {
+        "properties": {
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          },
+          "sources": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Sources"
+          }
+        },
+        "type": "object",
+        "required": [
+          "answer",
+          "sources"
+        ],
+        "title": "QAResponse"
+      },
+      "SourceMode": {
+        "type": "string",
+        "enum": [
+          "bible",
+          "both",
+          "catechism"
+        ],
+        "title": "SourceMode"
+      },
+      "SubscribeRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "SubscribeRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VerseOfTheDayResponse": {
+        "properties": {
+          "verse_text": {
+            "type": "string",
+            "title": "Verse Text"
+          },
+          "verse_reference": {
+            "type": "string",
+            "title": "Verse Reference"
+          }
+        },
+        "type": "object",
+        "required": [
+          "verse_text",
+          "verse_reference"
+        ],
+        "title": "VerseOfTheDayResponse"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBasic": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Return only verse text and reference in verse-of-the-day response
- Remove LLM and catechism logic from verse-of-the-day endpoint
- Regenerate OpenAPI docs for new response schema

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app
import json
with open('openapi.json','w') as f:
    json.dump(app.openapi(), f, indent=2)
print('generated')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bfa17e511c8323beda155b17c0ad75